### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Aurae AE
 
-Unix inspired command line client for Aurae written in Go! 
+Unix inspired command line client for Aurae written in Go!
 
-Contributions and newcomers to the project are welcome. Please see [Gettinv Involved](https://github.com/aurae-runtime/community#getting-involved) to join the Discord and more.
-
+Contributions and newcomers to the project are welcome. Please see [Getting Involved](https://github.com/aurae-runtime/community#getting-involved) to join the Discord and more.


### PR DESCRIPTION
Fixes the typo in `[Gettinv Involved](...)`