### PR TITLE
fix: add compile.go to compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,7 @@ compile: mod ## Compile for the local architecture ⚙
 	-X 'main.Copyright=$(copyright)' \
 	-X 'main.License=$(license)' \
 	-X 'main.Name=$(target)'" \
-	-o bin/$(target) main.go
-	chmod +x bin/*
+	-o bin/$(target) .
 
 mod: ## Go mod things
 	go mod tidy


### PR DESCRIPTION
Also removes the chmod, as `go build` should make an executable binary by default.

`.` will compile the current dir, but alternatives include `*.go` or the module name.