### PR TITLE
Ci workflow rounda

### DIFF
--- a/.github/workflows/ci-build-test.yaml
+++ b/.github/workflows/ci-build-test.yaml
@@ -3,7 +3,7 @@ name: Build Master Release versions
 on:
   push:
     branches:
-      - master
+      - main
 
 ## Publish a docker image with the CLI? Future use as a runjob maybe?
 env:

--- a/.github/workflows/ci-build-test.yaml
+++ b/.github/workflows/ci-build-test.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Get version 
         id: get_version
         run:
-          echo "::set-output name=VERSION::$(make version)"
+          echo "VERSION=$(make version)" > $GITHUB_OUTPUT
 
       - name: Build and Test using Docker
         run: |

--- a/.github/workflows/ci-build-test.yaml
+++ b/.github/workflows/ci-build-test.yaml
@@ -1,0 +1,58 @@
+name: Build Master Release versions
+
+on:
+  push:
+    branches:
+      - master
+
+## Publish a docker image with the CLI? Future use as a runjob maybe?
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: aurae-runtime/ae
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    ## needed to publish eventually to GHCR
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        shell: bash
+        working-directory: .
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v2
+
+      - name: Get version 
+        id: get_version
+        run:
+          echo "::set-output name=VERSION::$(make version)"
+
+      - name: Build and Test using Docker
+        run: |
+          make docker_release
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ steps.get_version.outputs.VERSION }}-rc"
+          prerelease: true
+          title: "Master Build RC"
+          files: |
+            LICENSE
+            build/release/*
+            
+
+#     - name: Log in to the Container registry
+#       uses: docker/login-action@v2
+#       with:
+#         registry: ${{ env.REGISTRY }}
+#         username: ${{ github.actor }}
+#         password: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/ci-build-test.yaml
+++ b/.github/workflows/ci-build-test.yaml
@@ -1,4 +1,4 @@
-name: Build Master Release versions
+name: Build Main Release versions
 
 on:
   push:

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -1,0 +1,41 @@
+name: Build Master Release versions
+
+on:
+  pull_request:
+
+## Publish a docker image with the CLI? Future use as a runjob maybe?
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: aurae-runtime/ae
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    ## needed to publish eventually to GHCR
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        shell: bash
+        working-directory: .
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and Test using Docker
+        run: |
+          make docker_pr
+
+#     - name: Log in to the Container registry
+#       uses: docker/login-action@v2
+#       with:
+#         registry: ${{ env.REGISTRY }}
+#         username: ${{ github.actor }}
+#         password: ${{ secrets.GITHUB_TOKEN }}
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 bin/*
 .idea*
 vendor/*
+
+ae
+build/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,6 @@
 FROM golang:1.19 as builder
 
 
-RUN mkdir -p /go/src/github.com/aurae-runtime/ae
 WORKDIR /go/src/github.com/aurae-runtime/ae
 ADD ./ /go/src/github.com/aurae-runtime/ae
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,10 @@
+FROM golang:1.19 as builder
+
+
+RUN mkdir -p /go/src/github.com/aurae-runtime/ae
+WORKDIR /go/src/github.com/aurae-runtime/ae
+ADD ./ /go/src/github.com/aurae-runtime/ae
+
+ARG makeArguments=vet clean test compile release
+
+RUN make $makeArguments

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@
 #                                                                              #
 # ---------------------------------------------------------------------------- #
 
-all: compile
 
 # Variables and Settings
 version     ?=  0.0.1
@@ -39,6 +38,20 @@ authoremail ?=  info@aurae.io
 license     ?=  Apache2
 year        ?=  2023
 copyright   ?=  Copyright (c) $(year)
+
+
+docker_release:
+	  docker build  --build-arg makeArguments="vet clean mod mod test compile release" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
+	  docker rm -f ae-temp-image 2>/dev/null
+	  docker run  --name ae-temp-image -d aurae-runtime/ae-builder 
+	  mkdir -p build
+	  docker cp ae-temp-image:/go/src/github.com/aurae-runtime/ae/release ./build
+	  docker rm -f ae-temp-image
+
+all: vet clean mod mod test compile install
+
+vet:
+	go vet .
 
 compile: mod ## Compile for the local architecture ⚙
 	@echo "Compiling..."
@@ -60,13 +73,16 @@ install: ## Install the program to /usr/bin 🎉
 	@echo "Installing..."
 	sudo cp $(target) /usr/bin/$(target)
 
-test: clean compile install ## 🤓 Run go tests
+test: clean compile ## 🤓 Run go tests
 	@echo "Testing..."
 	go test -v ./...
 
 clean: ## Clean your artifacts 🧼
 	@echo "Cleaning..."
 	rm -rvf release/*
+
+version:
+	@echo "$(version)"
 
 .PHONY: release
 release: ## Make the binaries for a GitHub release 📦

--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,13 @@ copyright   ?=  Copyright (c) $(year)
 
 docker_pr:
 	  docker build  --build-arg makeArguments="vet clean mod compile test" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
-	  docker rm -f ae-temp-image 2>/dev/null
-	  docker run  --name ae-temp-image -d aurae-runtime/ae-builder 
-	  mkdir -p build
-	  docker cp ae-temp-image:/go/src/github.com/aurae-runtime/ae/release ./build
-	  docker rm -f ae-temp-image
 
 docker_release:
 	  docker build  --build-arg makeArguments="clean mod compile test release" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
 	  docker rm -f ae-temp-image 2>/dev/null
 	  docker run  --name ae-temp-image -d aurae-runtime/ae-builder 
-	  mkdir -p build
-	  docker cp ae-temp-image:/go/src/github.com/aurae-runtime/ae/release ./build
+	  mkdir -p build/release
+	  docker cp ae-temp-image:/go/src/github.com/aurae-runtime/ae/build/release ./build
 	  docker rm -f ae-temp-image
 
 
@@ -88,19 +83,19 @@ test: clean compile ## 🤓 Run go tests
 
 clean: ## Clean your artifacts 🧼
 	@echo "Cleaning..."
-	rm -rvf release/*
+	rm -rvf build/
 
 version:
 	@echo "$(version)"
 
 .PHONY: release
 release: ## Make the binaries for a GitHub release 📦
-	mkdir -p release
-	GOOS="linux" GOARCH="amd64" go build -ldflags "-X 'main.Version=$(version)'" -o release/$(target)-linux-amd64 cmd/*.go
-	GOOS="linux" GOARCH="arm" go build -ldflags "-X 'main.Version=$(version)'" -o release/$(target)-linux-arm cmd/*.go
-	GOOS="linux" GOARCH="arm64" go build -ldflags "-X 'main.Version=$(version)'" -o release/$(target)-linux-arm64 cmd/*.go
-	GOOS="linux" GOARCH="386" go build -ldflags "-X 'main.Version=$(version)'" -o release/$(target)-linux-386 cmd/*.go
-	GOOS="darwin" GOARCH="amd64" go build -ldflags "-X 'main.Version=$(version)'" -o release/$(target)-darwin-amd64 cmd/*.go
+	mkdir -p build/release
+	GOOS="linux" GOARCH="amd64" go build -ldflags "-X 'main.Version=$(version)'" -o build/release/$(target)-linux-amd64 cmd/*.go
+	GOOS="linux" GOARCH="arm" go build -ldflags "-X 'main.Version=$(version)'" -o build/release/$(target)-linux-arm cmd/*.go
+	GOOS="linux" GOARCH="arm64" go build -ldflags "-X 'main.Version=$(version)'" -o build/release/$(target)-linux-arm64 cmd/*.go
+	GOOS="linux" GOARCH="386" go build -ldflags "-X 'main.Version=$(version)'" -o build/release/$(target)-linux-386 cmd/*.go
+	GOOS="darwin" GOARCH="amd64" go build -ldflags "-X 'main.Version=$(version)'" -o build/release/$(target)-darwin-amd64 cmd/*.go
 
 .PHONY: help
 help:  ## Show help messages for make targets

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,21 @@ copyright   ?=  Copyright (c) $(year)
 
 
 docker_release:
-	  docker build  --build-arg makeArguments="vet clean mod mod test compile release" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
+	  docker build  --build-arg makeArguments="vet clean mod mod compile test release" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
 	  docker rm -f ae-temp-image 2>/dev/null
 	  docker run  --name ae-temp-image -d aurae-runtime/ae-builder 
 	  mkdir -p build
 	  docker cp ae-temp-image:/go/src/github.com/aurae-runtime/ae/release ./build
 	  docker rm -f ae-temp-image
+
+docker_pr:
+	  docker build  --build-arg makeArguments="vet clean mod mod compile test" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
+	  docker rm -f ae-temp-image 2>/dev/null
+	  docker run  --name ae-temp-image -d aurae-runtime/ae-builder 
+	  mkdir -p build
+	  docker cp ae-temp-image:/go/src/github.com/aurae-runtime/ae/release ./build
+	  docker rm -f ae-temp-image
+
 
 all: vet clean mod mod test compile install
 

--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,16 @@ year        ?=  2023
 copyright   ?=  Copyright (c) $(year)
 
 
-docker_release:
-	  docker build  --build-arg makeArguments="vet clean mod mod compile test release" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
+docker_pr:
+	  docker build  --build-arg makeArguments="vet clean mod compile test" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
 	  docker rm -f ae-temp-image 2>/dev/null
 	  docker run  --name ae-temp-image -d aurae-runtime/ae-builder 
 	  mkdir -p build
 	  docker cp ae-temp-image:/go/src/github.com/aurae-runtime/ae/release ./build
 	  docker rm -f ae-temp-image
 
-docker_pr:
-	  docker build  --build-arg makeArguments="vet clean mod mod compile test" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
+docker_release:
+	  docker build  --build-arg makeArguments="clean mod compile test release" -t aurae-runtime/ae-builder -f ./Dockerfile.build .
 	  docker rm -f ae-temp-image 2>/dev/null
 	  docker run  --name ae-temp-image -d aurae-runtime/ae-builder 
 	  mkdir -p build


### PR DESCRIPTION
An initial release flow.  
* Changes default make to use a docker builder and generates a full release.  NOT sure if this is the best path or not and need to cleanup the makefile, but... kids are bugging me... so later.  NOTE... I find using this pattern MUCH cleaner for those who have different golang or other configs to deal with AND it's idempotent build wise ;) 
* Publishes files to a GH release on main (still runs tests here... )
* Validates a PR by doing a make/build/test in a docker image
