### PR TITLE
add test for version subcommand

### DIFF
--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -1,0 +1,80 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+package test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type Suite struct {
+	Title           string
+	Args            []string
+	ExpectedMessage string
+	IsErrorExpected bool
+}
+
+func ExecuteSuiteTest(t *testing.T, newCMD func() *cobra.Command, suites []Suite) {
+	for _, test := range suites {
+		t.Run(test.Title, func(t *testing.T) {
+			buffer := bytes.NewBufferString("")
+			cmd := newCMD()
+			cmd.SetOut(buffer)
+			cmd.SetErr(buffer)
+			cmd.SetArgs(test.Args)
+
+			err := cmd.Execute()
+			if test.IsErrorExpected {
+				if !IsNil(err) {
+					if !IsEqualString(test.ExpectedMessage, err.Error()) {
+						t.Errorf("\nError message of command \"%s\" was incorrect, got: \n%s\nwant: \n%s.", test.Title, err.Error(), test.ExpectedMessage)
+					}
+				} else {
+					t.Errorf("\nError in command \"%s\" expected.", test.Title)
+				}
+			} else if IsNil(err) {
+				if !IsEqualString(test.ExpectedMessage, buffer.String()) {
+					t.Errorf("\nTest of command \"%s\" was incorrect, got: \n%swant: \n%s.", test.Title, buffer.String(), test.ExpectedMessage)
+				}
+			}
+		})
+	}
+}
+
+func IsEqualString(s1, s2 string) bool {
+	return s1 == s2
+}
+
+func IsNil(object interface{}) bool {
+	return object == nil
+}

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -47,7 +47,7 @@ type Suite struct {
 func ExecuteSuiteTest(t *testing.T, newCMD func() *cobra.Command, suites []Suite) {
 	for _, test := range suites {
 		t.Run(test.Title, func(t *testing.T) {
-			buffer := bytes.NewBufferString("")
+			buffer := &bytes.Buffer{}
 			cmd := newCMD()
 			cmd.SetOut(buffer)
 			cmd.SetErr(buffer)

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -1,0 +1,72 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+package version
+
+import (
+	"testing"
+
+	cmdTest "github.com/aurae-runtime/ae/cmd/test"
+	"github.com/prometheus/common/version"
+)
+
+func TestVersionCMD(t *testing.T) {
+	version.Version = "v0.1.0"
+	version.BuildDate = "2023-01-07"
+	version.Revision = "a7c46aa017bc447ece506629196bd0548cbbc469"
+	testSuite := []cmdTest.Suite{
+		{
+			Title:           "empty args",
+			Args:            []string{},
+			IsErrorExpected: false,
+			ExpectedMessage: `buildTime: "2023-01-07"
+version: v0.1.0
+commit: a7c46aa017bc447ece506629196bd0548cbbc469
+
+`,
+		},
+		{
+			Title:           "print version in json",
+			Args:            []string{"--output", "json"},
+			IsErrorExpected: false,
+			ExpectedMessage: `{"buildTime":"2023-01-07","version":"v0.1.0","commit":"a7c46aa017bc447ece506629196bd0548cbbc469"}
+`,
+		},
+		{
+			Title:           "print short version",
+			Args:            []string{"--short"},
+			IsErrorExpected: false,
+			ExpectedMessage: `version: v0.1.0
+
+`,
+		},
+	}
+	cmdTest.ExecuteSuiteTest(t, NewCMD, testSuite)
+}


### PR DESCRIPTION
- Adds a test suite for testing commands.
- Adds a test for `version` subcommand as an example.