### PR TITLE
Feat/add pki create

### DIFF
--- a/cmd/pki/create.go
+++ b/cmd/pki/create.go
@@ -84,9 +84,10 @@ func (o *option) SetWriter(writer io.Writer) {
 func NewCMD() *cobra.Command {
 	o := &option{}
 	cmd := &cobra.Command{
-		Use:     "create",
-		Short:   "Creates a CA for auraed.",
-		Example: "ae create my.domain.com",
+		Use:   "create",
+		Short: "Creates a CA for auraed.",
+		Example: `ae create my.domain.com
+ae create --dir ./pki/ my.domain.com`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return aeCMD.Run(o, cmd, args)

--- a/cmd/pki/create/create.go
+++ b/cmd/pki/create/create.go
@@ -36,6 +36,7 @@ import (
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
 	"github.com/aurae-runtime/ae/pkg/cli"
+	"github.com/aurae-runtime/ae/pkg/cli/printer"
 	"github.com/aurae-runtime/ae/pkg/pki"
 	"github.com/spf13/cobra"
 )
@@ -66,11 +67,11 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	err := pki.CreateAuraeRootCA(o.directory, o.domain)
+	rootCA, err := pki.CreateAuraeRootCA(o.directory, o.domain)
 	if err != nil {
 		return fmt.Errorf("failed to create aurae root ca: %w", err)
 	}
-
+	o.outputFormat.ToPrinter().Print(o.writer, &rootCA)
 	return nil
 }
 
@@ -79,7 +80,12 @@ func (o *option) SetWriter(writer io.Writer) {
 }
 
 func NewCMD() *cobra.Command {
-	o := &option{}
+	o := &option{
+		outputFormat: cli.NewOutputFormat().
+			WithDefaultFormat(printer.NewJSON().Format()).
+			WithPrinter(printer.NewJSON()).
+			WithPrinter(printer.NewYAML()),
+	}
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates a CA for auraed.",

--- a/cmd/pki/create/create.go
+++ b/cmd/pki/create/create.go
@@ -66,7 +66,10 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	pki.CreateRootCA(o.directory, o.domain)
+	err := pki.CreateAuraeRootCA(o.directory, o.domain)
+	if err != nil {
+		return fmt.Errorf("failed to create aurae root ca: %w", err)
+	}
 
 	return nil
 }

--- a/cmd/pki/create/create.go
+++ b/cmd/pki/create/create.go
@@ -97,6 +97,7 @@ ae pki create --dir ./pki/ my.domain.com`,
 		},
 	}
 
+	o.outputFormat.AddFlags(cmd)
 	cmd.Flags().StringVarP(&o.directory, "dir", "d", o.directory, "Output directory to store CA files.")
 
 	return cmd

--- a/cmd/pki/create/create.go
+++ b/cmd/pki/create/create.go
@@ -28,30 +28,24 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-package pki_create
+package create
 
 import (
 	"fmt"
 	"io"
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
-	"github.com/aurae-runtime/ae/opt"
+	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/aurae-runtime/ae/pkg/pki"
 	"github.com/spf13/cobra"
 )
 
-type outputVersion struct {
-	BuildTime string `json:"buildTime,omitempty" yaml:"buildTime,omitempty"`
-	Version   string `json:"version" yaml:"version"`
-	Commit    string `json:"commit,omitempty" yaml:"commit,omitempty"`
-}
-
 type option struct {
 	aeCMD.Option
-	opt.OutputOption
-	directory string
-	domain    string
-	writer    io.Writer
+	outputFormat *cli.OutputFormat
+	directory    string
+	domain       string
+	writer       io.Writer
 }
 
 func (o *option) Complete(args []string) error {
@@ -86,8 +80,8 @@ func NewCMD() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates a CA for auraed.",
-		Example: `ae create my.domain.com
-ae create --dir ./pki/ my.domain.com`,
+		Example: `ae pki create my.domain.com
+ae pki create --dir ./pki/ my.domain.com`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return aeCMD.Run(o, cmd, args)

--- a/cmd/pki/create/create.go
+++ b/cmd/pki/create/create.go
@@ -46,6 +46,7 @@ type option struct {
 	outputFormat *cli.OutputFormat
 	directory    string
 	domain       string
+	silent       bool
 	writer       io.Writer
 }
 
@@ -71,7 +72,9 @@ func (o *option) Execute() error {
 	if err != nil {
 		return fmt.Errorf("failed to create aurae root ca: %w", err)
 	}
-	o.outputFormat.ToPrinter().Print(o.writer, &rootCA)
+	if !o.silent {
+		o.outputFormat.ToPrinter().Print(o.writer, &rootCA)
+	}
 	return nil
 }
 
@@ -85,6 +88,7 @@ func NewCMD() *cobra.Command {
 			WithDefaultFormat(printer.NewJSON().Format()).
 			WithPrinter(printer.NewJSON()).
 			WithPrinter(printer.NewYAML()),
+		silent: false,
 	}
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -99,6 +103,7 @@ ae pki create --dir ./pki/ my.domain.com`,
 
 	o.outputFormat.AddFlags(cmd)
 	cmd.Flags().StringVarP(&o.directory, "dir", "d", o.directory, "Output directory to store CA files.")
+	cmd.Flags().BoolVarP(&o.silent, "silent", "s", o.silent, "Silent mode, omits output")
 
 	return cmd
 }

--- a/cmd/pki/pki.go
+++ b/cmd/pki/pki.go
@@ -28,37 +28,49 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-package root_cmd
+package pki
 
 import (
-	"os"
+	"io"
 
-	"github.com/aurae-runtime/ae/cmd/oci"
-	pki "github.com/aurae-runtime/ae/cmd/pki"
-	"github.com/aurae-runtime/ae/cmd/version"
+	aeCMD "github.com/aurae-runtime/ae/cmd"
+	pki_create "github.com/aurae-runtime/ae/cmd/pki/create"
+	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "ae",
-	Short: "Unix inspired command line client for Aurae.\n",
-	Long:  `Unix inspired command line client for Aurae.`,
-	// TODO help by default
-	// Run: func(cmd *cobra.Command, args []string) { },
+type option struct {
+	aeCMD.Option
+	outputFormat *cli.OutputFormat
+	writer       io.Writer
 }
 
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+func (o *option) Complete(args []string) error {
+	return nil
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	return nil
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "pki",
+		Short: "Contains PKI related subcommands.",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return aeCMD.Run(o, cmd, args)
+		},
 	}
-}
-
-func init() {
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
-	// add subcommands
-	rootCmd.AddCommand(oci.NewCMD())
-	rootCmd.AddCommand(version.NewCMD())
-	rootCmd.AddCommand(pki.NewCMD())
+	cmd.AddCommand(pki_create.NewCMD())
+	return cmd
 }

--- a/cmd/pki/pki.go
+++ b/cmd/pki/pki.go
@@ -35,14 +35,12 @@ import (
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
 	pki_create "github.com/aurae-runtime/ae/cmd/pki/create"
-	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
 type option struct {
 	aeCMD.Option
-	outputFormat *cli.OutputFormat
-	writer       io.Writer
+	writer io.Writer
 }
 
 func (o *option) Complete(args []string) error {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -34,7 +34,7 @@ import (
 	"os"
 
 	"github.com/aurae-runtime/ae/cmd/oci"
-	pki "github.com/aurae-runtime/ae/cmd/pki"
+	"github.com/aurae-runtime/ae/cmd/pki"
 	"github.com/aurae-runtime/ae/cmd/version"
 	"github.com/spf13/cobra"
 )

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -1,0 +1,93 @@
+package pki
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+)
+
+func CreateRootCA(dir string, domainName string) {
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		fmt.Println("Failed to create directory:", err)
+		os.Exit(1)
+	}
+
+	template := x509.Certificate{}
+	template.Subject = pkix.Name{
+		Organization:       []string{"Aurae"},
+		OrganizationalUnit: []string{"Runtime"},
+		StreetAddress:      []string{"aurae"},
+		Locality:           []string{"aurae"},
+		Country:            []string{"IS"},
+		CommonName:         domainName,
+	}
+
+	template.NotBefore = time.Now()
+	template.NotAfter = template.NotBefore.Add(24 * time.Hour * 9999)
+	// template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign
+	// template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+	template.IsCA = true
+	template.BasicConstraintsValid = true
+	template.DNSNames = []string{domainName}
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		fmt.Println("Failed to generate private key:", err)
+		os.Exit(1)
+	}
+	pub := priv.PublicKey
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	template.SerialNumber, err = rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		fmt.Println("Failed to generate serial number:", err)
+		os.Exit(1)
+	}
+
+	// To get an AuthorityKeyId which is equal to SubjectKeyId, we are manually
+	// setting it according to the rules of x509.go.
+	//
+	// From X509 docs:
+	// The AuthorityKeyId will be taken from the SubjectKeyId of parent, if any,
+	// unless the resulting certificate is self-signed. Otherwise the value from
+	// template will be used.
+	//
+	// If SubjectKeyId from template is empty and the template is a CA, SubjectKeyId
+	// will be generated from the hash of the public key.
+
+	// We need a hash of the publickey, so hopefully this link is right
+	// https://stackoverflow.com/questions/52502511/how-to-generate-bytes-array-from-publickey#comment92269419_52502639
+	h := sha1.Sum(pub.N.Bytes())
+	template.SubjectKeyId = h[:]
+	template.AuthorityKeyId = template.SubjectKeyId
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		fmt.Println("Failed to create certificate:", err)
+		os.Exit(1)
+	}
+	crtDir := fmt.Sprintf("%sca.crt", dir)
+	certOut, err := os.Create(crtDir)
+	if err != nil {
+		fmt.Println("Failed to open ca.pem for writing:", err)
+		os.Exit(1)
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certOut.Close()
+	keyDir := fmt.Sprintf("%sca.key", dir)
+	keyOut, err := os.OpenFile(keyDir, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		fmt.Println("failed to open ca.key for writing:", err)
+		os.Exit(1)
+	}
+	pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	keyOut.Close()
+
+	fmt.Printf("Created CA files for domain \"%s\" \n\t%s\n\t%s\n", domainName, crtDir, keyDir)
+}

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -40,15 +40,21 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"time"
 )
 
-func CreateRootCA(dir string, domainName string) {
-	err := os.MkdirAll(dir, os.ModePerm)
-	if err != nil {
-		fmt.Println("Failed to create directory:", err)
-		os.Exit(1)
+func CreateAuraeRootCA(path string, domainName string) error {
+	path = filepath.Clean(path)
+
+	if path != "" {
+		err := os.MkdirAll(path, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("failed to create output directory: %w", err)
+		}
 	}
+	crtPath := filepath.Join(path, "ca.crt")
+	keyPath := filepath.Join(path, "ca.key")
 
 	template := x509.Certificate{}
 	template.Subject = pkix.Name{
@@ -59,65 +65,64 @@ func CreateRootCA(dir string, domainName string) {
 		Country:            []string{"IS"},
 		CommonName:         domainName,
 	}
-
 	template.NotBefore = time.Now()
 	template.NotAfter = template.NotBefore.Add(24 * time.Hour * 9999)
-	// template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign
-	// template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
 	template.IsCA = true
 	template.BasicConstraintsValid = true
 	template.DNSNames = []string{domainName}
+
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		fmt.Println("Failed to generate private key:", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to generate private key: %w", err)
 	}
-	pub := priv.PublicKey
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	template.SerialNumber, err = rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		fmt.Println("Failed to generate serial number:", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to generate serial number: %w", err)
 	}
 
 	// To get an AuthorityKeyId which is equal to SubjectKeyId, we are manually
 	// setting it according to the rules of x509.go.
 	//
 	// From X509 docs:
-	// The AuthorityKeyId will be taken from the SubjectKeyId of parent, if any,
-	// unless the resulting certificate is self-signed. Otherwise the value from
-	// template will be used.
+	// > The AuthorityKeyId will be taken from the SubjectKeyId of parent, if any,
+	// > unless the resulting certificate is self-signed. Otherwise the value from
+	// > template will be used.
 	//
-	// If SubjectKeyId from template is empty and the template is a CA, SubjectKeyId
-	// will be generated from the hash of the public key.
-
+	// > If SubjectKeyId from template is empty and the template is a CA, SubjectKeyId
+	// > will be generated from the hash of the public key.
+	//
 	// We need a hash of the publickey, so hopefully this link is right
 	// https://stackoverflow.com/questions/52502511/how-to-generate-bytes-array-from-publickey#comment92269419_52502639
-	h := sha1.Sum(pub.N.Bytes())
-	template.SubjectKeyId = h[:]
+	pubHash := sha1.Sum(priv.PublicKey.N.Bytes())
+	template.SubjectKeyId = pubHash[:]
 	template.AuthorityKeyId = template.SubjectKeyId
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
-		fmt.Println("Failed to create certificate:", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create certificate: %w", err)
 	}
-	crtDir := fmt.Sprintf("%sca.crt", dir)
-	certOut, err := os.Create(crtDir)
+
+	certOut, err := os.Create(crtPath)
 	if err != nil {
-		fmt.Println("Failed to open ca.pem for writing:", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to open ca.pem for writing: %w", err)
 	}
-	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	pem.Encode(certOut, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
 	certOut.Close()
-	keyDir := fmt.Sprintf("%sca.key", dir)
-	keyOut, err := os.OpenFile(keyDir, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+
+	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
-		fmt.Println("failed to open ca.key for writing:", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to open ca.key for writing: %w", err)
 	}
-	pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	pem.Encode(keyOut, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
 	keyOut.Close()
 
-	fmt.Printf("Created CA files for domain \"%s\" \n\t%s\n\t%s\n", domainName, crtDir, keyDir)
+	fmt.Printf("Created root ca for domain \"%s\" \n\t%s\n\t%s\n", domainName, crtPath, keyPath)
+	return nil
 }

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -1,3 +1,33 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
 package pki
 
 import (


### PR DESCRIPTION
Feature as part of #23 that introduces `ae create` to generate a rootCA.

Usage
```
$ ./bin/ae create -h                     
Creates a CA for auraed.

Usage:
  ae create [flags]

Examples:
ae create my.domain.com
ae create --dir ./pki/ my.domain.com

Flags:
  -d, --dir string   Output directory to store CA files.
  -h, --help         help for create
```

Using it:

```
$ ./bin/ae create -d ./pki/ my.domain.com
Created CA files for domain "my.domain.com" 
        ./pki/ca.crt
        ./pki/ca.key
```

OpenSSL output of generated `ca.crt`:

```
openssl x509 -in ./pki/ca.crt -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            e1:9d:46:64:72:00:4e:fd:12:4c:ea:2a:b9:74:50:dd
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C = IS, L = aurae, street = aurae, O = Aurae, OU = Runtime, CN = my.domain.com
        Validity
            Not Before: Jan  8 22:32:49 2023 GMT
            Not After : May 25 22:32:49 2050 GMT
        Subject: C = IS, L = aurae, street = aurae, O = Aurae, OU = Runtime, CN = my.domain.com
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:c2:5b:e5:fb:ba:37:55:21:07:96:50:08:03:bc:
                    69:59:51:ba:00:4a:b4:52:cd:7a:7b:44:fd:8a:a1:
                    ff:41:ae:ce:0f:64:75:0d:61:7f:b1:84:be:7b:f9:
                    4d:b7:4f:39:cc:b1:c1:ad:21:6b:31:ea:39:e7:68:
                    25:12:5b:58:b3:81:bf:0e:32:f7:80:36:9e:e4:83:
                    72:06:f8:21:67:c2:3e:a7:3b:99:1c:30:bc:b7:03:
                    87:88:ba:08:a8:f8:2a:60:6e:c1:56:0a:00:36:54:
                    c5:dd:60:ea:6e:50:cf:7e:47:25:60:16:63:97:1c:
                    cc:a6:c9:26:08:ad:5b:d0:69:2b:3f:08:90:51:97:
                    28:fd:85:d8:05:84:f8:98:34:47:62:9c:4a:59:c9:
                    07:94:3a:02:1e:87:3c:02:6d:bf:8f:85:3f:1e:ff:
                    b6:58:ea:cf:f6:a8:5b:ff:97:88:7b:5d:c5:d8:61:
                    c9:b5:c4:02:16:44:09:74:d1:c6:a8:7a:43:a2:0c:
                    ec:92:1f:11:4a:69:55:d3:3d:d2:4a:30:95:cb:4e:
                    4d:39:84:9b:a8:9f:df:41:dc:25:2f:3c:98:95:13:
                    bc:14:0f:3f:26:5d:95:4a:f0:db:e2:c1:1b:14:c9:
                    63:35:8f:f2:66:b0:ff:85:b0:f7:bf:57:62:11:84:
                    09:73
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Key Identifier: 
                14:B2:ED:9D:02:CD:F4:F1:60:67:86:FF:32:3F:19:D8:98:8A:CA:14
            X509v3 Authority Key Identifier: 
                14:B2:ED:9D:02:CD:F4:F1:60:67:86:FF:32:3F:19:D8:98:8A:CA:14
            X509v3 Subject Alternative Name: 
                DNS:my.domain.com
    Signature Algorithm: sha256WithRSAEncryption
    Signature Value:
        0e:cf:a8:da:e5:cf:f7:8f:5a:e6:88:66:ea:eb:e0:28:f8:93:
        ae:ee:1c:de:c7:2a:7c:9d:3f:0d:07:a7:78:e9:c7:ba:d0:33:
        f0:76:25:e9:20:70:9d:aa:8a:cf:f9:52:60:82:7f:0c:65:a0:
        64:05:c8:6b:7a:74:72:9f:96:0a:09:70:32:0d:ec:e6:ac:70:
        21:fb:cb:15:cf:11:27:bb:96:e7:b8:ab:4e:c4:8c:c6:85:85:
        50:64:11:41:45:f0:f2:ee:86:f2:77:d7:68:0c:b0:8a:35:68:
        34:d5:16:08:e8:fc:a6:19:c0:25:21:ec:8b:73:c7:4a:6c:dc:
        31:5a:8c:77:b7:b1:06:66:bc:ec:b2:3d:c4:d7:0f:bb:9d:ca:
        60:ae:b4:bd:7a:b7:e4:0b:38:52:70:ab:45:b2:35:dc:10:05:
        ac:91:b6:a5:db:11:4e:73:b6:56:71:4a:a6:68:e6:b6:48:42:
        27:13:4a:98:97:e7:a9:c7:27:35:ec:51:5d:7f:e0:43:68:25:
        52:a4:88:ae:9e:67:cd:52:2b:d1:f2:c3:21:f7:80:fc:5b:cb:
        67:e2:80:73:31:21:1b:46:7d:0e:06:21:c9:f6:03:07:50:f2:
        b0:0e:e8:8f:8c:31:64:33:e9:88:f3:bb:64:ab:1a:14:f7:8c:
```

I tried to mimic the rootCA generated during `make pki` as close as possible.

Before I proceed, I'd like to ask for some feedback on the structure & approach.