### PR TITLE
Remove oci_ prefix to follow Go style guide

### DIFF
--- a/cmd/oci/create/create.go
+++ b/cmd/oci/create/create.go
@@ -28,7 +28,7 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-package oci
+package create
 
 import (
 	"fmt"
@@ -56,7 +56,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	fmt.Fprintln(o.writer, "start called")
+	fmt.Fprintln(o.writer, "create called")
 	return nil
 }
 
@@ -71,9 +71,9 @@ func NewCMD() *cobra.Command {
 			WithPrinter(printer.NewYAML()),
 	}
 	cmd := &cobra.Command{
-		Use:   "start",
-		Short: "Start the user-specified code from process.",
-		Long:  `Start the user-specified code from process.`,
+		Use:   "create",
+		Short: "Create a container from a bundle directory.",
+		Long:  `Create a container from a bundle directory.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return aeCMD.Run(o, cmd, args)
 		},

--- a/cmd/oci/delete/delete.go
+++ b/cmd/oci/delete/delete.go
@@ -28,7 +28,7 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-package oci_state
+package delete
 
 import (
 	"fmt"
@@ -56,7 +56,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	fmt.Fprintln(o.writer, "state called")
+	fmt.Fprintln(o.writer, "delete called")
 	return nil
 }
 
@@ -71,9 +71,9 @@ func NewCMD() *cobra.Command {
 			WithPrinter(printer.NewYAML()),
 	}
 	cmd := &cobra.Command{
-		Use:   "state",
-		Short: "Request the container state.",
-		Long:  `Request the container state.`,
+		Use:   "delete",
+		Short: "Release container resources after the container process has exited.",
+		Long:  `Release container resources after the container process has exited.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return aeCMD.Run(o, cmd, args)
 		},

--- a/cmd/oci/kill/kill.go
+++ b/cmd/oci/kill/kill.go
@@ -28,7 +28,7 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-package oci_create
+package kill
 
 import (
 	"fmt"
@@ -56,7 +56,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	fmt.Fprintln(o.writer, "create called")
+	fmt.Fprintln(o.writer, "kill called")
 	return nil
 }
 
@@ -71,9 +71,9 @@ func NewCMD() *cobra.Command {
 			WithPrinter(printer.NewYAML()),
 	}
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a container from a bundle directory.",
-		Long:  `Create a container from a bundle directory.`,
+		Use:   "kill",
+		Short: "Send a signal to the container process.",
+		Long:  `Send a signal to the container process.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return aeCMD.Run(o, cmd, args)
 		},

--- a/cmd/oci/oci.go
+++ b/cmd/oci/oci.go
@@ -35,11 +35,11 @@ import (
 	"io"
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
-	ociCreate "github.com/aurae-runtime/ae/cmd/oci/create"
-	ociDelete "github.com/aurae-runtime/ae/cmd/oci/delete"
-	ociKill "github.com/aurae-runtime/ae/cmd/oci/kill"
-	ociStart "github.com/aurae-runtime/ae/cmd/oci/start"
-	ociState "github.com/aurae-runtime/ae/cmd/oci/state"
+	"github.com/aurae-runtime/ae/cmd/oci/create"
+	"github.com/aurae-runtime/ae/cmd/oci/delete"
+	"github.com/aurae-runtime/ae/cmd/oci/kill"
+	"github.com/aurae-runtime/ae/cmd/oci/start"
+	"github.com/aurae-runtime/ae/cmd/oci/state"
 	"github.com/spf13/cobra"
 )
 
@@ -76,11 +76,11 @@ func NewCMD() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(ociCreate.NewCMD())
-	cmd.AddCommand(ociDelete.NewCMD())
-	cmd.AddCommand(ociKill.NewCMD())
-	cmd.AddCommand(ociStart.NewCMD())
-	cmd.AddCommand(ociState.NewCMD())
+	cmd.AddCommand(create.NewCMD())
+	cmd.AddCommand(delete.NewCMD())
+	cmd.AddCommand(kill.NewCMD())
+	cmd.AddCommand(start.NewCMD())
+	cmd.AddCommand(state.NewCMD())
 
 	return cmd
 }

--- a/cmd/oci/start/start.go
+++ b/cmd/oci/start/start.go
@@ -28,7 +28,7 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-package oci_delete
+package start
 
 import (
 	"fmt"
@@ -56,7 +56,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	fmt.Fprintln(o.writer, "delete called")
+	fmt.Fprintln(o.writer, "start called")
 	return nil
 }
 
@@ -71,9 +71,9 @@ func NewCMD() *cobra.Command {
 			WithPrinter(printer.NewYAML()),
 	}
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Release container resources after the container process has exited.",
-		Long:  `Release container resources after the container process has exited.`,
+		Use:   "start",
+		Short: "Start the user-specified code from process.",
+		Long:  `Start the user-specified code from process.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return aeCMD.Run(o, cmd, args)
 		},

--- a/cmd/oci/state/state.go
+++ b/cmd/oci/state/state.go
@@ -28,7 +28,7 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-package oci_kill
+package state
 
 import (
 	"fmt"
@@ -56,7 +56,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	fmt.Fprintln(o.writer, "kill called")
+	fmt.Fprintln(o.writer, "state called")
 	return nil
 }
 
@@ -71,9 +71,9 @@ func NewCMD() *cobra.Command {
 			WithPrinter(printer.NewYAML()),
 	}
 	cmd := &cobra.Command{
-		Use:   "kill",
-		Short: "Send a signal to the container process.",
-		Long:  `Send a signal to the container process.`,
+		Use:   "state",
+		Short: "Request the container state.",
+		Long:  `Request the container state.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return aeCMD.Run(o, cmd, args)
 		},

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -13,16 +13,16 @@ Example: `ae oci` is a 1st level subcommand and therefore stored in `./cmd/oci/`
 ├── cmd.go
 ├── oci
 │   ├── create
-│   │   └── oci_create.go
+│   │   └── create.go
 │   ├── delete
-│   │   └── oci_delete.go
+│   │   └── delete.go
 │   ├── kill
-│   │   └── oci_kill.go
+│   │   └── kill.go
 │   ├── oci.go
 │   ├── start
-│   │   └── oci_start.go
+│   │   └── start.go
 │   └── state
-│       └── oci_state.go
+│       └── state.go
 ├── root
 │   └── root.go
 ├── runtime


### PR DESCRIPTION
See https://go.dev/doc/effective_go#package-names

```
Another convention is that the package name is the base name of its source directory; the package in src/encoding/base64 is imported as "encoding/base64" but has name base64, not encoding_base64 and not encodingBase64.
```