### PR TITLE
Add runtime subcommands

### DIFF
--- a/cmd/runtime/allocate/allocate.go
+++ b/cmd/runtime/allocate/allocate.go
@@ -1,0 +1,77 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+package allocate
+
+import (
+	"io"
+
+	aeCMD "github.com/aurae-runtime/ae/cmd"
+	"github.com/aurae-runtime/ae/opt"
+	"github.com/aurae-runtime/ae/output"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	aeCMD.Option
+	opt.OutputOption
+	writer io.Writer
+}
+
+func (o *option) Complete(_ []string) error {
+	return nil
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	return output.HandleString(o.writer, "allocate called")
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "allocate",
+		Short: "Allocate a runtime resource.",
+		Long:  `Allocate a runtime resource.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return aeCMD.Run(o, cmd, args)
+		},
+	}
+	// add flags here
+
+	return cmd
+}

--- a/cmd/runtime/free/free.go
+++ b/cmd/runtime/free/free.go
@@ -1,0 +1,77 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+package free
+
+import (
+	"io"
+
+	aeCMD "github.com/aurae-runtime/ae/cmd"
+	"github.com/aurae-runtime/ae/opt"
+	"github.com/aurae-runtime/ae/output"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	aeCMD.Option
+	opt.OutputOption
+	writer io.Writer
+}
+
+func (o *option) Complete(_ []string) error {
+	return nil
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	return output.HandleString(o.writer, "free called")
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "free",
+		Short: "Free a runtime resource.",
+		Long:  `Free a runtime resource.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return aeCMD.Run(o, cmd, args)
+		},
+	}
+	// add flags here
+
+	return cmd
+}

--- a/cmd/runtime/runtime.go
+++ b/cmd/runtime/runtime.go
@@ -1,0 +1,93 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+package runtime
+
+import (
+	"io"
+
+	aeCMD "github.com/aurae-runtime/ae/cmd"
+	allocate "github.com/aurae-runtime/ae/cmd/runtime/allocate"
+	free "github.com/aurae-runtime/ae/cmd/runtime/free"
+	start "github.com/aurae-runtime/ae/cmd/runtime/start"
+	stop "github.com/aurae-runtime/ae/cmd/runtime/stop"
+	"github.com/aurae-runtime/ae/opt"
+	"github.com/aurae-runtime/ae/output"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	aeCMD.Option
+	opt.OutputOption
+	writer io.Writer
+}
+
+func (o *option) Complete(_ []string) error {
+	return nil
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	return output.HandleString(o.writer, "runtime called")
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "runtime",
+		Short: "CLI for aurae runtime services.",
+		Long:  `CLI for aurae runtime services.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return aeCMD.Run(o, cmd, args)
+		},
+	}
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// startCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// startCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	cmd.AddCommand(allocate.NewCMD())
+	cmd.AddCommand(free.NewCMD())
+	cmd.AddCommand(start.NewCMD())
+	cmd.AddCommand(stop.NewCMD())
+
+	return cmd
+}

--- a/cmd/runtime/start/start.go
+++ b/cmd/runtime/start/start.go
@@ -1,0 +1,77 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+package start
+
+import (
+	"io"
+
+	aeCMD "github.com/aurae-runtime/ae/cmd"
+	"github.com/aurae-runtime/ae/opt"
+	"github.com/aurae-runtime/ae/output"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	aeCMD.Option
+	opt.OutputOption
+	writer io.Writer
+}
+
+func (o *option) Complete(_ []string) error {
+	return nil
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	return output.HandleString(o.writer, "start called")
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start a runtime resource.",
+		Long:  `Start a runtime resource.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return aeCMD.Run(o, cmd, args)
+		},
+	}
+	// add flags here
+
+	return cmd
+}

--- a/cmd/runtime/stop/stop.go
+++ b/cmd/runtime/stop/stop.go
@@ -1,0 +1,77 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+package stop
+
+import (
+	"io"
+
+	aeCMD "github.com/aurae-runtime/ae/cmd"
+	"github.com/aurae-runtime/ae/opt"
+	"github.com/aurae-runtime/ae/output"
+	"github.com/spf13/cobra"
+)
+
+type option struct {
+	aeCMD.Option
+	opt.OutputOption
+	writer io.Writer
+}
+
+func (o *option) Complete(_ []string) error {
+	return nil
+}
+
+func (o *option) Validate() error {
+	return nil
+}
+
+func (o *option) Execute() error {
+	return output.HandleString(o.writer, "stop called")
+}
+
+func (o *option) SetWriter(writer io.Writer) {
+	o.writer = writer
+}
+
+func NewCMD() *cobra.Command {
+	o := &option{}
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop a runtime resource.",
+		Long:  `Stop a runtime resource.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return aeCMD.Run(o, cmd, args)
+		},
+	}
+	// add flags here
+
+	return cmd
+}

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -25,6 +25,15 @@ Example: `ae oci` is a 1st level subcommand and therefore stored in `./cmd/oci/`
 │       └── oci_state.go
 ├── root
 │   └── root.go
+├── runtime
+│   ├── allocate
+│   │   └── allocate.go
+│   ├── free
+│   │   └── free.go
+│   ├── start
+│   │   └── start.go
+│   └── stop
+│       └── stop.go
 └── version
     └── version.go
 ```


### PR DESCRIPTION
*Assuming both get merged, this PR will need to be rebase with https://github.com/aurae-runtime/ae/pull/29 depending on which gets merged first.*

Fix #9 
Fix #10 
Fix #11 
Fix #12 

Add `runtime` subcommands basic structure:

```
├── runtime
│   ├── allocate
│   │   └── allocate.go
│   ├── free
│   │   └── free.go
│   ├── start
│   │   └── start.go
│   └── stop
│       └── stop.go
```