### PR TITLE
fix dependencies of runtime cmd

### DIFF
--- a/cmd/runtime/allocate/allocate.go
+++ b/cmd/runtime/allocate/allocate.go
@@ -34,15 +34,14 @@ import (
 	"io"
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
-	"github.com/aurae-runtime/ae/opt"
-	"github.com/aurae-runtime/ae/output"
+	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
 type option struct {
 	aeCMD.Option
-	opt.OutputOption
-	writer io.Writer
+	outputFormat *cli.OutputFormat
+	writer       io.Writer
 }
 
 func (o *option) Complete(_ []string) error {
@@ -54,7 +53,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	return output.HandleString(o.writer, "allocate called")
+	return o.outputFormat.ToPrinter().Print(o.writer, "allocate called")
 }
 
 func (o *option) SetWriter(writer io.Writer) {

--- a/cmd/runtime/free/free.go
+++ b/cmd/runtime/free/free.go
@@ -34,15 +34,14 @@ import (
 	"io"
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
-	"github.com/aurae-runtime/ae/opt"
-	"github.com/aurae-runtime/ae/output"
+	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
 type option struct {
 	aeCMD.Option
-	opt.OutputOption
-	writer io.Writer
+	outputFormat *cli.OutputFormat
+	writer       io.Writer
 }
 
 func (o *option) Complete(_ []string) error {
@@ -54,7 +53,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	return output.HandleString(o.writer, "free called")
+	return o.outputFormat.ToPrinter().Print(o.writer, "free called")
 }
 
 func (o *option) SetWriter(writer io.Writer) {

--- a/cmd/runtime/runtime.go
+++ b/cmd/runtime/runtime.go
@@ -38,15 +38,14 @@ import (
 	free "github.com/aurae-runtime/ae/cmd/runtime/free"
 	start "github.com/aurae-runtime/ae/cmd/runtime/start"
 	stop "github.com/aurae-runtime/ae/cmd/runtime/stop"
-	"github.com/aurae-runtime/ae/opt"
-	"github.com/aurae-runtime/ae/output"
+	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
 type option struct {
 	aeCMD.Option
-	opt.OutputOption
-	writer io.Writer
+	outputFormat *cli.OutputFormat
+	writer       io.Writer
 }
 
 func (o *option) Complete(_ []string) error {
@@ -58,7 +57,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	return output.HandleString(o.writer, "runtime called")
+	return o.outputFormat.ToPrinter().Print(o.writer, "runtime called")
 }
 
 func (o *option) SetWriter(writer io.Writer) {

--- a/cmd/runtime/start/start.go
+++ b/cmd/runtime/start/start.go
@@ -34,15 +34,14 @@ import (
 	"io"
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
-	"github.com/aurae-runtime/ae/opt"
-	"github.com/aurae-runtime/ae/output"
+	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
 type option struct {
 	aeCMD.Option
-	opt.OutputOption
-	writer io.Writer
+	outputFormat *cli.OutputFormat
+	writer       io.Writer
 }
 
 func (o *option) Complete(_ []string) error {
@@ -54,7 +53,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	return output.HandleString(o.writer, "start called")
+	return o.outputFormat.ToPrinter().Print(o.writer, "start called")
 }
 
 func (o *option) SetWriter(writer io.Writer) {

--- a/cmd/runtime/stop/stop.go
+++ b/cmd/runtime/stop/stop.go
@@ -34,15 +34,14 @@ import (
 	"io"
 
 	aeCMD "github.com/aurae-runtime/ae/cmd"
-	"github.com/aurae-runtime/ae/opt"
-	"github.com/aurae-runtime/ae/output"
+	"github.com/aurae-runtime/ae/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
 type option struct {
 	aeCMD.Option
-	opt.OutputOption
-	writer io.Writer
+	outputFormat *cli.OutputFormat
+	writer       io.Writer
 }
 
 func (o *option) Complete(_ []string) error {
@@ -54,7 +53,7 @@ func (o *option) Validate() error {
 }
 
 func (o *option) Execute() error {
-	return output.HandleString(o.writer, "stop called")
+	return o.outputFormat.ToPrinter().Print(o.writer, "stop called")
 }
 
 func (o *option) SetWriter(writer io.Writer) {


### PR DESCRIPTION
This fixes a regression we got during the last merges. This makes `ae` build again.