### PR TITLE
fix: version tests

### DIFF
--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -57,14 +57,14 @@ func ExecuteSuiteTest(t *testing.T, newCMD func() *cobra.Command, suites []Suite
 			if test.IsErrorExpected {
 				if !IsNil(err) {
 					if !IsEqualString(test.ExpectedMessage, err.Error()) {
-						t.Errorf("\nError message of command \"%s\" was incorrect, got: \n%s\nwant: \n%s.", test.Title, err.Error(), test.ExpectedMessage)
+						t.Errorf("\nError message of command %q was incorrect, got: \n%s\nwant: \n%s", test.Title, err.Error(), test.ExpectedMessage)
 					}
 				} else {
-					t.Errorf("\nError in command \"%s\" expected.", test.Title)
+					t.Errorf("\nError in command %q expected.", test.Title)
 				}
 			} else if IsNil(err) {
 				if !IsEqualString(test.ExpectedMessage, buffer.String()) {
-					t.Errorf("\nTest of command \"%s\" was incorrect, got: \n%swant: \n%s.", test.Title, buffer.String(), test.ExpectedMessage)
+					t.Errorf("\nTest of command %q was incorrect, got: \n%s\nwant: \n%s", test.Title, buffer.String(), test.ExpectedMessage)
 				}
 			}
 		})

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -46,26 +46,19 @@ func TestVersionCMD(t *testing.T) {
 			Title:           "empty args",
 			Args:            []string{},
 			IsErrorExpected: false,
-			ExpectedMessage: `buildTime: "2023-01-07"
-version: v0.1.0
-commit: a7c46aa017bc447ece506629196bd0548cbbc469
-
-`,
-		},
-		{
-			Title:           "print version in json",
-			Args:            []string{"--output", "json"},
-			IsErrorExpected: false,
-			ExpectedMessage: `{"buildTime":"2023-01-07","version":"v0.1.0","commit":"a7c46aa017bc447ece506629196bd0548cbbc469"}
-`,
+			ExpectedMessage: `{
+    "buildTime": "2023-01-07",
+    "version": "v0.1.0",
+    "commit": "a7c46aa017bc447ece506629196bd0548cbbc469"
+}`,
 		},
 		{
 			Title:           "print short version",
 			Args:            []string{"--short"},
 			IsErrorExpected: false,
-			ExpectedMessage: `version: v0.1.0
-
-`,
+			ExpectedMessage: `{
+    "version": "v0.1.0"
+}`,
 		},
 	}
 	cmdTest.ExecuteSuiteTest(t, NewCMD, testSuite)

--- a/pkg/cli/printer/json.go
+++ b/pkg/cli/printer/json.go
@@ -24,7 +24,6 @@ func (printer *JSON) Print(w io.Writer, obj any) error {
 		return err
 	}
 
-	data = append(data, '\n')
 	_, err = w.Write(data)
 	return err
 }


### PR DESCRIPTION
Fixes tests so that #33 passes.

1. It appears there is no longer normal "text" printing from what I could glean from other PRs, so I've altered the tests to expect JSON.
2. I've remove the final newline from the JSON output. While it might look a bit weird to print out into console with it missing, it's _technically_ more correct to not having a trailing newline afaict. 
I would be happy to revert that change and alter the tests if you'd rather keep the trailing newline.

![pass](https://user-images.githubusercontent.com/42128690/211677062-ae426fda-082d-46c6-acbd-44130d5476b6.png)
