### PR TITLE
run lint as a separate action

### DIFF
--- a/.github/workflows/001-go-ubuntu-latest-make-test-format.yaml
+++ b/.github/workflows/001-go-ubuntu-latest-make-test-format.yaml
@@ -36,19 +36,6 @@ jobs:
       - name: Run formatting
         run: make check-format
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '>=1.19.4'
-          cache: true
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v3
-
   editorconfig:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/002-go-ubuntu-latest-make-lint.yaml
+++ b/.github/workflows/002-go-ubuntu-latest-make-lint.yaml
@@ -1,0 +1,21 @@
+name: Lint
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.4'
+          cache: true
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+


### PR DESCRIPTION
golangci-lint docs recommend running lint separately from tests so there's no parallelism issues