### PR TITLE
deactivate golangci-lint gh action

### DIFF
--- a/.github/workflows/001-go-ubuntu-latest-make-test-format-lint.yaml
+++ b/.github/workflows/001-go-ubuntu-latest-make-test-format-lint.yaml
@@ -45,6 +45,12 @@ jobs:
         with:
           go-version: '>=1.19.4'
 
+      - name: Make proto
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
+        run: make proto
+
       - name: Lint
         uses: golangci/golangci-lint-action@v3
 


### PR DESCRIPTION
Deactivating golangci-lint for now, as it doesn't create reproducible linting errors.