### PR TITLE
skip tidy error when versions mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ goreleaser: ## Run goreleaser directly at the pinned version 🛠
 
 .PHONY: mod
 mod: proto ## Go mod things
-	go mod tidy
+	go mod tidy -e
 	go mod vendor
 	go mod download
 


### PR DESCRIPTION
example error: "go: go.mod file indicates go 1.20, but maximum version supported by tidy is 1.19"

i believe there's the "right way" to fix this (i'm running go 1.20, i can't find anything that requires v 1.19 in the tree) but this allows make to complete.